### PR TITLE
Update implementation to handle "now" case

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-ago",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "Simple time ago for Unix timestamps and JavaScript Date objects.",
   "main": "dist/index.js",
   "scripts": {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,5 +1,9 @@
 import js_ago from "../src/index";
 
+it('should format Unix timestamps of "now"', () => {
+  expect(js_ago(new Date())).toEqual("now");
+});
+
 it("should format Unix timestamps of X seconds ago with long format", () => {
   expect(js_ago(getTimestamp(1, "s"), { format: "long" })).toEqual(
     "1 second ago",
@@ -11,13 +15,16 @@ it("should format Unix timestamps of X seconds ago with long format", () => {
 
 it("should format Unix timestamps of X minutes ago with short format", () => {
   expect(js_ago(getTimestamp(60, "s"), { format: "short" })).toEqual("1m ago");
-  expect(js_ago(getTimestamp(61, "s"), { format: "short" })).toEqual("2m ago");
+  expect(js_ago(getTimestamp(65, "s"), { format: "short" })).toEqual("1m ago");
+  expect(js_ago(getTimestamp(120, "s"), { format: "short" })).toEqual("2m ago");
+  expect(js_ago(getTimestamp(150, "s"), { format: "short" })).toEqual("2m ago");
   expect(js_ago(getTimestamp(59, "m"), { format: "short" })).toEqual("59m ago");
 });
 
 it("should format Unix timestamps of X hours ago correctly", () => {
   expect(js_ago(getTimestamp(60, "m"))).toEqual("1 hr ago");
-  expect(js_ago(getTimestamp(61, "m"))).toEqual("2 hrs ago");
+  expect(js_ago(getTimestamp(61, "m"))).toEqual("1 hr ago");
+  expect(js_ago(getTimestamp(130, "m"))).toEqual("2 hrs ago");
   expect(js_ago(getTimestamp(23, "h"))).toEqual("23 hrs ago");
 });
 
@@ -28,25 +35,52 @@ it("should format Unix timestamps of X days ago correctly", () => {
 
 it("should format Unix timestamps of X weeks ago correctly", () => {
   expect(js_ago(getTimestamp(7, "d"))).toEqual("1 wk ago");
-  expect(js_ago(getTimestamp(8, "d"))).toEqual("2 wks ago");
-  expect(js_ago(getTimestamp(20, "d"))).toEqual("3 wks ago");
-  expect(js_ago(getTimestamp(22, "d"))).toEqual("4 wks ago");
+  expect(js_ago(getTimestamp(20, "d"))).toEqual("2 wks ago");
+  expect(js_ago(getTimestamp(22, "d"))).toEqual("3 wks ago");
+  expect(js_ago(getTimestamp(28, "d"))).toEqual("4 wks ago");
 });
 
 it("should format Unix timestamps of X months ago correctly", () => {
-  expect(js_ago(getTimestamp(28, "d"))).toEqual("1 mon ago");
   expect(js_ago(getTimestamp(31, "d"))).toEqual("1 mon ago");
-  expect(js_ago(getTimestamp(32, "d"))).toEqual("2 mons ago");
+  expect(js_ago(getTimestamp(32, "d"))).toEqual("1 mon ago");
+  expect(js_ago(getTimestamp(60, "d"))).toEqual("2 mons ago");
 });
 
 it("should format Unix timestamps of X years ago correctly", () => {
   expect(js_ago(getTimestamp(365, "d"))).toEqual("1 yr ago");
-  expect(js_ago(getTimestamp(366, "d"))).toEqual("2 yrs ago");
+  expect(js_ago(getTimestamp(366, "d"))).toEqual("1 yr ago");
   expect(js_ago(getTimestamp(8, "y"))).toEqual("8 yrs ago");
 });
 
 it("should format Date object to time ago", () => {
-  expect(js_ago(new Date("2018-02-05"))).toEqual("7 yrs ago");
+  expect(js_ago(new Date("2018-02-05"))).toEqual("6 yrs ago");
+});
+
+describe("Invalid inputs", () => {
+  it("should throw an error when format is not supported", () => {
+    try {
+      // @ts-expect-error Testing invalid input
+      js_ago(new Date("2024-02-04"), { format: "not_supported" });
+
+      expect(true).toBeFalsy();
+    } catch (err) {
+      expect((err as Error).message).toEqual(
+        "The provided format is incorrect.",
+      );
+    }
+  });
+
+  it("should throw an error when time is in the future", () => {
+    try {
+      js_ago(new Date("2030-02-05"));
+
+      expect(true).toBeFalsy();
+    } catch (err) {
+      expect((err as Error).message).toEqual(
+        "The time difference is negative. The provided timestamp is in the future.",
+      );
+    }
+  });
 });
 
 function getTimestamp(amount: number, unit: string) {


### PR DESCRIPTION
- Handle "now" case
- Display `1 hour ago` instead of `2 hours ago` when the diff is between 60-119 mins (same for other units)